### PR TITLE
Remove [const unit], and refactoring

### DIFF
--- a/lib/MonadPHP/Chain.php
+++ b/lib/MonadPHP/Chain.php
@@ -13,19 +13,17 @@ class Chain extends Maybe {
 
     public function __get($name) {
         return $this->bind(function($obj) use($name) {
-            if (isset($obj->$name)) {
-                return $obj->$name;
-            }
-            return null;
+            return isset($obj->$name)
+                ? $obj->$name
+                : null;
         });
     }
 
     public function __call($name, array $args = array()) {
         return $this->bind(function($obj) use ($name, $args) {
-            if (is_callable(array($obj, $name))) {
-                return call_user_func_array(array($obj, $name), $args);
-            }
-            return null;
+            return is_callable(array($obj, $name))
+                ? call_user_func_array(array($obj, $name), $args)
+                : null;
         });
     }
 

--- a/lib/MonadPHP/Identity.php
+++ b/lib/MonadPHP/Identity.php
@@ -4,6 +4,4 @@ namespace MonadPHP;
 
 class Identity extends Monad {
 
-    const unit = "MonadPHP\Identity::unit";
-
 }

--- a/lib/MonadPHP/ListMonad.php
+++ b/lib/MonadPHP/ListMonad.php
@@ -2,13 +2,14 @@
 
 namespace MonadPHP;
 
+use InvalidArgumentException;
+use Traversable;
+
 class ListMonad extends Monad {
 
-    const unit = "MonadPHP\ListMonad::unit";
-
     public function __construct($value) {
-        if (!is_array($value) && !$value instanceof \Traversable) {
-            throw new \InvalidArgumentException('Must be traversable');
+        if (!is_array($value) && !$value instanceof Traversable) {
+            throw new InvalidArgumentException('Must be traversable');
         }
         return parent::__construct($value);
     }
@@ -18,19 +19,11 @@ class ListMonad extends Monad {
         foreach ($this->value as $value) {
             $result[] = $this->runCallback($function, $value, $args);
         }
-        return $this::unit($result);
+        return static::unit($result);
     }
 
     public function extract() {
-        $ret = array();
-        foreach ($this->value as $value) {
-            if ($value instanceof Monad) {
-                $ret[] = $value->extract();
-            } else {
-                $ret[] = $value;
-            }
-        }
-        return $ret;
+        return array_map([get_called_class(), 'extractValue'], $this->value);
     }
 
 }

--- a/lib/MonadPHP/Maybe.php
+++ b/lib/MonadPHP/Maybe.php
@@ -4,13 +4,10 @@ namespace MonadPHP;
 
 class Maybe extends Monad {
 
-    const unit = "MonadPHP\Maybe::unit";
-
-    public function bind($function){
-        if (!is_null($this->value)) {
-            return parent::bind($function);
-        }
-        return $this::unit(null);
+    public function bind($function) {
+        return is_null($this->value)
+            ? static::unit(null)
+            : parent::bind($function);
     }
 
 }

--- a/lib/MonadPHP/Monad.php
+++ b/lib/MonadPHP/Monad.php
@@ -11,21 +11,23 @@ abstract class Monad {
     }
 
     public static function unit($value) {
-        if ($value instanceof static) {
-            return $value;
-        }
-        return new static($value);
+        return $value instanceof static
+            ? $value
+            : new static($value);
     }
 
     public function bind($function, array $args = array()) {
-        return $this::unit($this->runCallback($function, $this->value, $args));
+        return static::unit($this->runCallback($function, $this->value, $args));
     }
 
     public function extract() {
-        if ($this->value instanceof self) {
-            return $this->value->extract();
-        }
-        return $this->value;
+        return static::extractValue($this->value);
+    }
+
+    public static function extractValue($value) {
+        return $value instanceof self
+            ? $value->extract()
+            : $value;
     }
 
     protected function runCallback($function, $value, array $args = array()) {

--- a/lib/MonadPHP/Promise.php
+++ b/lib/MonadPHP/Promise.php
@@ -2,9 +2,9 @@
 
 namespace MonadPHP;
 
-class Promise extends Monad {
+use BadMethodCallException;
 
-    const unit = "MonadPHP\Promise::unit";
+class Promise extends Monad {
 
     protected $isResolved = false;
     protected $succeed = null;
@@ -19,22 +19,21 @@ class Promise extends Monad {
     }
 
     public static function unit($success = null, $failure = null) {
-        return new Promise($success, $failure); 
+        return new Promise($success, $failure);
     }
 
     public function bind($success, $failure) {
-        $obj = $this->unit($success, $failure);
-        if ($this->isResolved) {
-            $obj->resolve($this->succeed, $this->value);
-        } else {
-            $this->children[] = $obj;
-        }
+        $obj = static::unit($success, $failure);
+        $this->isResolved
+            ? $obj->resolve($this->succeed, $this->value)
+            : $this->children[] = $obj;
+
         return $obj;
     }
 
     protected function resolve($status, $value) {
         if ($this->isResolved) {
-            throw new \BadMethodCallException('Promise already resolved');
+            throw new BadMethodCallException('Promise already resolved');
         }
         $this->value = $value;
         $this->isResolved = true;

--- a/test/MonadPHP/IdentityTest.php
+++ b/test/MonadPHP/IdentityTest.php
@@ -6,12 +6,12 @@ class IdentityTest extends \PHPUnit_Framework_TestCase {
 
     public function testBind() {
         $monad = new Identity(1);
-        $this->assertEquals($monad->unit(1), $monad->bind('intval'));
+        $this->assertEquals($monad::unit(1), $monad->bind('intval'));
     }
 
     public function testBindUnit() {
         $monad = new Identity(1);
-        $this->assertEquals($monad, $monad->bind($monad::unit));
+        $this->assertEquals($monad, $monad->bind([$monad, 'unit']));
     }
 
     public function testExtract() {


### PR DESCRIPTION
in php 5.3 we not need $this->unit(...) we can use static::unit without any const and any duplicate code in brackets look like '"MonadPHP\Identity::unit"
